### PR TITLE
[Fix/#25] - 연결 수정(RefreshToken Cookie)

### DIFF
--- a/DevDo/src/main/java/com/devdo/global/oauth2/AuthLoginService.java
+++ b/DevDo/src/main/java/com/devdo/global/oauth2/AuthLoginService.java
@@ -35,7 +35,7 @@ public class AuthLoginService {
                 .secure(true)
                 .path("/")
                 .maxAge(Long.parseLong(jwtTokenProvider.getRefreshTokenExpireTime()) / 1000)
-                .sameSite("Strict")
+                .sameSite("None")
                 .build();
 
         return ResponseEntity.ok()


### PR DESCRIPTION
Fix/#25: RefreshToken cookie 설정 수정

배포 사이트로 요청 전송하니 리프레시 토큰이 없다고 재발급이 안 되어서 찾아보니 samSite 설정이 Strict 로 되어있으면 쿠키가 전송이 안 된대요
백, 프론트의 도메인이 다르기에 쿠키 전송에는 제한이 없어야 한대요