### PR TITLE
[Fix/#25] - Cookie 설정 변경

### DIFF
--- a/DevDo/src/main/java/com/devdo/global/oauth2/AuthLoginService.java
+++ b/DevDo/src/main/java/com/devdo/global/oauth2/AuthLoginService.java
@@ -8,17 +8,26 @@ import com.devdo.global.jwt.JwtTokenProvider;
 import com.devdo.member.domain.Member;
 import com.devdo.member.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class AuthLoginService {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+
+    @Value("${jwt.cookieSecure}")
+    private boolean cookieSecure;
+
+    @Value("${jwt.cookieSameSite}")
+    private String cookieSameSite;
 
     // refreshToken 저장
     public ResponseEntity<ApiResTemplate<String>> loginSuccess(Member member) {
@@ -32,11 +41,14 @@ public class AuthLoginService {
         // HttpOnly 쿠키로 리프레시 토큰 전달
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieSecure)
                 .path("/")
                 .maxAge(Long.parseLong(jwtTokenProvider.getRefreshTokenExpireTime()) / 1000)
-                .sameSite("None")
+                .sameSite(cookieSameSite)
                 .build();
+
+        System.out.println("cookieSecure = " + cookieSecure);
+        System.out.println("cookieSameSite = " + cookieSameSite);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())

--- a/DevDo/src/main/resources/application.yml
+++ b/DevDo/src/main/resources/application.yml
@@ -26,6 +26,8 @@ logging:
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity-in-milliseconds: ${JWT_ACCESS_TOKEN_VALIDITY_IN_MILLISECONDS}
+  cookieSecure: ${COOKIE_SECURE}
+  cookieSameSite: ${COOKIE_SAMESITE}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}


### PR DESCRIPTION
Fix/#25: Cookie 변수 설정 변경

- 리프레시 토큰 연결 중 프론트의 로컬 http -> 서버 배포 https 간 쿠키 전송이 안 되는 것을 확인(http -> http 간 쿠키 전송은 되는 것 확인 완)
- cookie 설정을 지정해 놓는 것이 아니라 prod에서 관리함으로 프론트 로컬 http -> https 간 쿠키 전송이 될 수 있도록 수정
- 이후 로컬 연동이 끝난 후 https -> https 간 쿠키 전송이 될 수 있도록 수정할 예정