### PR TITLE
[Feat/#15] - Roadmap 기능 구현

### DIFF
--- a/DevDo/src/main/java/com/devdo/common/error/ErrorCode.java
+++ b/DevDo/src/main/java/com/devdo/common/error/ErrorCode.java
@@ -34,6 +34,9 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 댓글이 없습니다. commentId = ", "NOT_FOUND_404"),
     MEMBER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 사용자가 없습니다. memberId = ", "NOT_FOUND_404"),
     COMMUNITY_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 게시글이 없습니다. communityId = ", "NOT_FOUND_404"),
+    NODE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 노드가 없습니다. nodeId = ", "NOT_FOUND_404"),
+    ROADMAP_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 로드맵이 없습니다. roadmapId = ", "NOT_FOUND_404"),
+
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다", "INTERNAL_SERVER_ERROR_500");

--- a/DevDo/src/main/java/com/devdo/node/controller/NodeController.java
+++ b/DevDo/src/main/java/com/devdo/node/controller/NodeController.java
@@ -1,0 +1,58 @@
+package com.devdo.node.controller;
+
+import com.devdo.node.controller.dto.response.NodeDetailResponseDto;
+import com.devdo.node.controller.dto.response.NodeResponseDto;
+import com.devdo.node.service.NodeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/roadmap/node")
+@Tag(name = "노드 API", description = "Node 관련 API들 입니다.")
+public class NodeController {
+
+    private final NodeService nodeService;
+
+    @PostMapping
+    @Operation(method = "POST", summary = "노드 추가", description = "노드를 추가합니다. (부모노드가 없을 시 parentNodeId에 null을 입력해주세요!)")
+    public ResponseEntity<NodeDetailResponseDto> createNode(
+            Principal principal,
+            @RequestBody NodeDetailResponseDto nodeDetailResponseDto
+    ) {
+        return ResponseEntity.ok(nodeService.createNode(principal, nodeDetailResponseDto));
+    }
+
+    @GetMapping("/{nodeId}")
+    @Operation(method = "GET", summary = "노드 조회", description = "노드를 조회합니다.")
+    public ResponseEntity<NodeResponseDto> getNodeDetail(
+            @PathVariable Long nodeId
+    ) {
+        return ResponseEntity.ok(nodeService.getNodeDetail(nodeId));
+    }
+
+    @PutMapping("/{nodeId}")
+    @Operation(method = "PUT", summary = "노드 수정", description = "노드를 수정합니다. (부모노드가 없을 시 parentNodeId에 null을 입력해주세요!)")
+    public ResponseEntity<NodeDetailResponseDto> updateNode(
+            Principal principal,
+            @PathVariable Long nodeId,
+            @RequestBody NodeDetailResponseDto nodeDetailResponseDto
+    ) {
+        return ResponseEntity.ok(nodeService.updateNode(principal, nodeId, nodeDetailResponseDto));
+    }
+
+    @DeleteMapping("/{nodeId}")
+    @Operation(method = "DEIETE", summary = "노드 삭제", description = "노드를 삭제합니다.")
+    public ResponseEntity<Void> deleteNode(
+            Principal principal,
+            @PathVariable Long nodeId
+    ) {
+        nodeService.deleteNode(principal, nodeId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/DevDo/src/main/java/com/devdo/node/controller/dto/request/NodeCreateRequestDto.java
+++ b/DevDo/src/main/java/com/devdo/node/controller/dto/request/NodeCreateRequestDto.java
@@ -1,0 +1,11 @@
+package com.devdo.node.controller.dto.request;
+
+import com.devdo.node.entity.NodeShape;
+
+public record NodeCreateRequestDto(
+        String nodeName,
+        NodeShape nodeShape,
+        String imageUrl,
+        String link
+) {
+}

--- a/DevDo/src/main/java/com/devdo/node/controller/dto/response/NodeDetailResponseDto.java
+++ b/DevDo/src/main/java/com/devdo/node/controller/dto/response/NodeDetailResponseDto.java
@@ -1,0 +1,27 @@
+package com.devdo.node.controller.dto.response;
+
+import com.devdo.node.entity.Node;
+import com.devdo.node.entity.NodeColor;
+import com.devdo.node.entity.NodeShape;
+
+public record NodeDetailResponseDto(
+        Long roadmapId,
+        String nodeName,
+        NodeShape nodeShape,
+        NodeColor nodeColor,
+        String pictureUrl,
+        String link,
+        Long parentNodeId
+) {
+    public static NodeDetailResponseDto from(Node node) {
+        return new NodeDetailResponseDto(
+                node.getRoadmap().getId(),
+                node.getNodeName(),
+                node.getNodeShape(),
+                node.getNodeColor(),
+                node.getPictureUrl(),
+                node.getLink(),
+                node.getParentNode() != null ? node.getParentNode().getNodeId() : null
+        );
+    }
+}

--- a/DevDo/src/main/java/com/devdo/node/controller/dto/response/NodeResponseDto.java
+++ b/DevDo/src/main/java/com/devdo/node/controller/dto/response/NodeResponseDto.java
@@ -1,0 +1,16 @@
+package com.devdo.node.controller.dto.response;
+
+import com.devdo.node.entity.Node;
+import com.devdo.node.entity.NodeShape;
+
+public record NodeResponseDto(
+        String nodeName,
+        NodeShape nodeShape
+) {
+    public static NodeResponseDto from(Node node) {
+        return new NodeResponseDto(
+                node.getNodeName(),
+                node.getNodeShape()
+        );
+    }
+}

--- a/DevDo/src/main/java/com/devdo/node/entity/Node.java
+++ b/DevDo/src/main/java/com/devdo/node/entity/Node.java
@@ -1,0 +1,67 @@
+package com.devdo.node.entity;
+
+import com.devdo.nodepage.entity.NodePage;
+import com.devdo.roadmap.entity.Roadmap;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Node {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "node_id")
+    private Long nodeId;
+
+    @Column(nullable = false)
+    private String nodeName;
+
+    private String pictureUrl;
+
+    private String link;
+
+    @Enumerated(EnumType.STRING)
+    private NodeShape nodeShape;
+
+    @Enumerated(EnumType.STRING)
+    private NodeColor nodeColor;
+
+    // 연관 로드맵
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "roadmap_id", nullable = false)
+    private Roadmap roadmap;
+
+    // 부모 노드
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_node_id")
+    private Node parentNode;
+
+    // 자식 노드
+    @OneToMany(mappedBy = "parentNode", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Node> children = new ArrayList<>();
+
+    @OneToOne(mappedBy = "node", cascade = CascadeType.ALL, orphanRemoval = true)
+    private NodePage nodePage;
+
+    public void addChild(Node child) {
+        children.add(child);
+        child.parentNode = this;
+    }
+
+    public void updateNode(Roadmap roadmap, String nodeName, NodeShape nodeShape, NodeColor nodeColor, String pictureUrl, String link, Node parentNode) {
+        this.roadmap = roadmap;
+        this.nodeName = nodeName;
+        this.nodeColor = nodeColor;
+        this.nodeShape = nodeShape;
+        this.pictureUrl = pictureUrl;
+        this.link = link;
+        this.parentNode = parentNode;
+    }
+}

--- a/DevDo/src/main/java/com/devdo/node/entity/NodeColor.java
+++ b/DevDo/src/main/java/com/devdo/node/entity/NodeColor.java
@@ -1,0 +1,5 @@
+package com.devdo.node.entity;
+
+public enum NodeColor {
+    WHITE, RED, GREEN, BLUE, YELLOW, PURPLE
+}

--- a/DevDo/src/main/java/com/devdo/node/entity/NodeShape.java
+++ b/DevDo/src/main/java/com/devdo/node/entity/NodeShape.java
@@ -1,0 +1,5 @@
+package com.devdo.node.entity;
+
+public enum NodeShape {
+    CIRCLE, RECTANGLE, DIAMOND
+}

--- a/DevDo/src/main/java/com/devdo/node/repository/NodeRepository.java
+++ b/DevDo/src/main/java/com/devdo/node/repository/NodeRepository.java
@@ -1,0 +1,14 @@
+package com.devdo.node.repository;
+
+
+import com.devdo.node.entity.Node;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NodeRepository extends JpaRepository<Node, Long> {
+
+    List<Node> findByRoadmap_Id(Long roadmapId);
+    List<Node> findByParentNode_NodeId(Long parentId);
+}
+

--- a/DevDo/src/main/java/com/devdo/node/service/NodeService.java
+++ b/DevDo/src/main/java/com/devdo/node/service/NodeService.java
@@ -1,0 +1,120 @@
+package com.devdo.node.service;
+
+import com.devdo.common.error.ErrorCode;
+import com.devdo.common.exception.BusinessException;
+import com.devdo.member.domain.Member;
+import com.devdo.member.domain.repository.MemberRepository;
+import com.devdo.node.controller.dto.response.NodeDetailResponseDto;
+import com.devdo.node.controller.dto.response.NodeResponseDto;
+import com.devdo.node.entity.Node;
+import com.devdo.node.repository.NodeRepository;
+import com.devdo.roadmap.entity.Roadmap;
+import com.devdo.roadmap.repository.RoadmapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Principal;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NodeService {
+
+    private final NodeRepository nodeRepository;
+    private final MemberRepository memberRepository;
+    private final RoadmapRepository roadmapRepository;
+
+    // 공통 메서드
+    @Transactional(readOnly = true)
+    public Member findMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION
+                        , ErrorCode.MEMBER_NOT_FOUND_EXCEPTION.getMessage() + id));
+    }
+
+    @Transactional(readOnly = true)
+    public Member getMemberFromPrincipal(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION
+                    , ErrorCode.FORBIDDEN_EXCEPTION.getMessage());
+        }
+        try {
+            Long memberId = Long.parseLong(principal.getName());
+            return findMemberById(memberId);
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_EXCEPTION
+                    , ErrorCode.FORBIDDEN_EXCEPTION.getMessage());
+        }
+    }
+
+    // 주요 서비스 메서드
+    public NodeDetailResponseDto createNode(Principal principal, NodeDetailResponseDto nodeDetailResponseDto) {
+        Member member = getMemberFromPrincipal(principal);
+
+        Roadmap roadmap = roadmapRepository.findById(nodeDetailResponseDto.roadmapId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROADMAP_NOT_FOUND_EXCEPTION, ErrorCode.ROADMAP_NOT_FOUND_EXCEPTION.getMessage()));
+
+        Node parent = null;
+        if (nodeDetailResponseDto.parentNodeId() != null) {
+            parent = nodeRepository.findById(nodeDetailResponseDto.parentNodeId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+        }
+
+        Node node = Node.builder()
+                .nodeName(nodeDetailResponseDto.nodeName())
+                .nodeShape(nodeDetailResponseDto.nodeShape())
+                .link(nodeDetailResponseDto.link())
+                .pictureUrl(nodeDetailResponseDto.pictureUrl())
+                .roadmap(roadmap)
+                .parentNode(parent)
+                .build();
+
+        return NodeDetailResponseDto.from(nodeRepository.save(node));
+    }
+
+    @Transactional(readOnly = true)
+    public NodeResponseDto getNodeDetail(Long nodeId) {
+        Node node = nodeRepository.findById(nodeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        return NodeResponseDto.from(node);
+    }
+
+    public NodeDetailResponseDto updateNode(Principal principal, Long nodeId, NodeDetailResponseDto nodeDetailResponseDto) {
+        Member member = getMemberFromPrincipal(principal);
+
+        Node node = nodeRepository.findById(nodeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        Roadmap roadmap = roadmapRepository.findById(nodeDetailResponseDto.roadmapId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROADMAP_NOT_FOUND_EXCEPTION, ErrorCode.ROADMAP_NOT_FOUND_EXCEPTION.getMessage()));
+
+        Node parentNode = null;
+        if (nodeDetailResponseDto.parentNodeId() != null) {
+            parentNode = nodeRepository.findById(nodeDetailResponseDto.parentNodeId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+        }
+
+        node.updateNode(
+                roadmap,
+                nodeDetailResponseDto.nodeName(),
+                nodeDetailResponseDto.nodeShape(),
+                nodeDetailResponseDto.nodeColor(),
+                nodeDetailResponseDto.pictureUrl(),
+                nodeDetailResponseDto.link(),
+                parentNode
+        );
+
+        return NodeDetailResponseDto.from(node);
+    }
+
+
+    public void deleteNode(Principal principal, Long nodeId) {
+        Member member = getMemberFromPrincipal(principal);
+        Node node = nodeRepository.findById(nodeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        nodeRepository.delete(node);
+    }
+}

--- a/DevDo/src/main/java/com/devdo/nodepage/controller/NodePageController.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/controller/NodePageController.java
@@ -1,0 +1,36 @@
+package com.devdo.nodepage.controller;
+
+import com.devdo.nodepage.controller.dto.request.NodePageRequestDto;
+import com.devdo.nodepage.controller.dto.response.NodePageResponseDto;
+import com.devdo.nodepage.service.NodePageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/roadmap/node/detail")
+@RequiredArgsConstructor
+@Tag(name = "노드 상세 페이지 API", description = "Node Detail Page 관련 API들 입니다. 노드 상세페이지 삭제는 노드를 삭제하면 함께 삭제됩니다.")
+public class NodePageController {
+
+    private final NodePageService nodePageService;
+
+    @PostMapping("/{nodeId}")
+    @Operation(method = "POST", summary = "노드 상세 페이지 추가", description = "노드 상세 페이지를 추가합니다. (노드 1개당 1개의 페이지만 추가 가능합니다.")
+    public NodePageResponseDto createNodePage(@PathVariable Long nodeId, @RequestBody NodePageRequestDto request) {
+        return nodePageService.create(nodeId, request);
+    }
+
+    @GetMapping("/{nodeId}")
+    @Operation(method = "GET", summary = "노드 상세 페이지 조회", description = "노드 상세 페이지를 조회합니다.")
+    public NodePageResponseDto getNodePage(@PathVariable Long nodeId) {
+        return nodePageService.get(nodeId);
+    }
+
+    @PutMapping("/{nodeId}")
+    @Operation(method = "PUT", summary = "노드 상세 페이지 수정", description = "노드 상세 페이지를 수정합니다.")
+    public NodePageResponseDto updateNodePage(@PathVariable Long nodeId, @RequestBody NodePageRequestDto request) {
+        return nodePageService.update(nodeId, request);
+    }
+}

--- a/DevDo/src/main/java/com/devdo/nodepage/controller/dto/request/NodePageRequestDto.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/controller/dto/request/NodePageRequestDto.java
@@ -1,0 +1,8 @@
+package com.devdo.nodepage.controller.dto.request;
+
+public record NodePageRequestDto(
+        String content,
+        String emoji,
+        String pictureUrl
+) {
+}

--- a/DevDo/src/main/java/com/devdo/nodepage/controller/dto/response/NodePageResponseDto.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/controller/dto/response/NodePageResponseDto.java
@@ -1,0 +1,10 @@
+package com.devdo.nodepage.controller.dto.response;
+
+public record NodePageResponseDto(
+        Long nodePageId,
+        String title,
+        String content,
+        String emoji,
+        String pictureUrl
+) {
+}

--- a/DevDo/src/main/java/com/devdo/nodepage/entity/NodePage.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/entity/NodePage.java
@@ -1,0 +1,46 @@
+package com.devdo.nodepage.entity;
+
+import com.devdo.node.entity.Node;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NodePage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "node_page_id")
+    private Long nodePageId;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private String pictureUrl;
+
+    // 페이지 상단의 이모지
+    private String emoji;
+
+    public String getTitle() {
+        return node.getNodeName(); // node의 nodeName을 반환
+    }
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "node_id", nullable = false)
+    private Node node;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateEmoji(String emoji) {
+        this.emoji = emoji;
+    }
+
+    public void updatePictureUrl(String pictureUrl) {
+        this.pictureUrl = pictureUrl;
+    }
+}

--- a/DevDo/src/main/java/com/devdo/nodepage/repository/NodePageRepository.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/repository/NodePageRepository.java
@@ -1,0 +1,10 @@
+package com.devdo.nodepage.repository;
+
+import com.devdo.nodepage.entity.NodePage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NodePageRepository extends JpaRepository<NodePage, Long> {
+    Optional<NodePage> findByNode_NodeId(Long nodeId);
+}

--- a/DevDo/src/main/java/com/devdo/nodepage/service/NodePageService.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/service/NodePageService.java
@@ -1,0 +1,84 @@
+package com.devdo.nodepage.service;
+
+import com.devdo.common.error.ErrorCode;
+import com.devdo.common.exception.BusinessException;
+import com.devdo.node.entity.Node;
+import com.devdo.node.repository.NodeRepository;
+import com.devdo.nodepage.controller.dto.request.NodePageRequestDto;
+import com.devdo.nodepage.controller.dto.response.NodePageResponseDto;
+import com.devdo.nodepage.entity.NodePage;
+import com.devdo.nodepage.repository.NodePageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NodePageService {
+
+    private final NodeRepository nodeRepository;
+    private final NodePageRepository nodePageRepository;
+
+    @Transactional
+    public NodePageResponseDto create(Long nodeId, NodePageRequestDto request) {
+        Node node = nodeRepository.findById(nodeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        NodePage nodePage = NodePage.builder()
+                .node(node)
+                .content(request.content())
+                .emoji(request.emoji())
+                .pictureUrl(request.pictureUrl())
+                .build();
+
+        NodePage saved = nodePageRepository.save(nodePage);
+
+        return new NodePageResponseDto(
+                saved.getNodePageId(),
+                saved.getTitle(),
+                saved.getContent(),
+                saved.getEmoji(),
+                saved.getPictureUrl()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public NodePageResponseDto get(Long nodeId) {
+        NodePage nodePage = nodePageRepository.findByNode_NodeId(nodeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        return new NodePageResponseDto(
+                nodePage.getNodePageId(),
+                nodePage.getTitle(),
+                nodePage.getContent(),
+                nodePage.getEmoji(),
+                nodePage.getPictureUrl()
+        );
+    }
+
+    @Transactional
+    public NodePageResponseDto update(Long nodeId, NodePageRequestDto request) {
+        NodePage nodePage = nodePageRepository.findByNode_NodeId(nodeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        nodePage.updateContent(request.content());
+        nodePage.updateEmoji(request.emoji());
+        nodePage.updatePictureUrl(request.pictureUrl());
+
+        return new NodePageResponseDto(
+                nodePage.getNodePageId(),
+                nodePage.getTitle(),
+                nodePage.getContent(),
+                nodePage.getEmoji(),
+                nodePage.getPictureUrl()
+        );
+    }
+
+    @Transactional
+    public void delete(Long nodeId) {
+        NodePage nodePage = nodePageRepository.findByNode_NodeId(nodeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NODE_NOT_FOUND_EXCEPTION, ErrorCode.NODE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        nodePageRepository.delete(nodePage);
+    }
+}

--- a/DevDo/src/main/java/com/devdo/roadmap/controller/RoadmapController.java
+++ b/DevDo/src/main/java/com/devdo/roadmap/controller/RoadmapController.java
@@ -1,0 +1,46 @@
+package com.devdo.roadmap.controller;
+
+import com.devdo.roadmap.controller.dto.request.RoadmapRequestDto;
+import com.devdo.roadmap.controller.dto.response.RoadmapResponseDto;
+import com.devdo.roadmap.service.RoadmapService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/roadmap")
+@RequiredArgsConstructor
+@Tag(name = "로드맵 API", description = "Roadmap 관련 API들 입니다.")
+public class RoadmapController {
+
+    private final RoadmapService roadmapService;
+
+    @PostMapping
+    @Operation(method = "POST", summary = "로드맵 추가", description = "로드맵 추가합니다.")
+    public Long createRoadmap(@RequestBody RoadmapRequestDto roadmapRequestDto,
+                              @RequestParam Long memberId) {
+        return roadmapService.createRoadmap(roadmapRequestDto, memberId);
+    }
+
+    @GetMapping("/my")
+    @Operation(method = "GET", summary = "로드맵 조회", description = "로드맵을 조회합니다.")
+    public List<RoadmapResponseDto> getMyRoadmaps(@RequestParam Long memberId) {
+        return roadmapService.getMyRoadmaps(memberId);
+    }
+
+    @PutMapping("/title/{roadmapId}")
+    @Operation(method = "PUT", summary = "로드맵 수정", description = "로드맵을 수정합니다.")
+    public void updateRoadmap(@PathVariable Long roadmapId,
+                              @RequestParam String newTitle) {
+        roadmapService.updateRoadmap(roadmapId, newTitle);
+    }
+
+    @DeleteMapping("/{roadmapId}")
+    @Operation(method = "DELETE", summary = "로드맵 삭제", description = "로드맵을 삭제합니다.")
+    public void deleteRoadmap(@PathVariable Long roadmapId) {
+        roadmapService.deleteRoadmap(roadmapId);
+    }
+}

--- a/DevDo/src/main/java/com/devdo/roadmap/controller/dto/request/RoadmapRequestDto.java
+++ b/DevDo/src/main/java/com/devdo/roadmap/controller/dto/request/RoadmapRequestDto.java
@@ -1,0 +1,6 @@
+package com.devdo.roadmap.controller.dto.request;
+
+public record RoadmapRequestDto(
+        String title
+) {
+}

--- a/DevDo/src/main/java/com/devdo/roadmap/controller/dto/response/RoadmapResponseDto.java
+++ b/DevDo/src/main/java/com/devdo/roadmap/controller/dto/response/RoadmapResponseDto.java
@@ -1,0 +1,14 @@
+package com.devdo.roadmap.controller.dto.response;
+
+import com.devdo.roadmap.entity.Roadmap;
+import lombok.Builder;
+
+@Builder
+public record RoadmapResponseDto(
+        Long roadmapId,
+        String title
+) {
+    public static RoadmapResponseDto from(Roadmap roadmap) {
+        return new RoadmapResponseDto(roadmap.getId(), roadmap.getTitle());
+    }
+}

--- a/DevDo/src/main/java/com/devdo/roadmap/entity/Roadmap.java
+++ b/DevDo/src/main/java/com/devdo/roadmap/entity/Roadmap.java
@@ -1,0 +1,35 @@
+package com.devdo.roadmap.entity;
+
+import com.devdo.member.domain.Member;
+import com.devdo.node.entity.Node;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Roadmap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "roadmap_id")
+    private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "roadmap", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Node> nodes = new ArrayList<>();
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+}

--- a/DevDo/src/main/java/com/devdo/roadmap/repository/RoadmapRepository.java
+++ b/DevDo/src/main/java/com/devdo/roadmap/repository/RoadmapRepository.java
@@ -1,0 +1,10 @@
+package com.devdo.roadmap.repository;
+
+import com.devdo.roadmap.entity.Roadmap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
+    List<Roadmap> findAllByMember_MemberId(Long memberId);
+}

--- a/DevDo/src/main/java/com/devdo/roadmap/service/RoadmapService.java
+++ b/DevDo/src/main/java/com/devdo/roadmap/service/RoadmapService.java
@@ -1,0 +1,59 @@
+package com.devdo.roadmap.service;
+
+import com.devdo.member.domain.Member;
+import com.devdo.member.domain.repository.MemberRepository;
+import com.devdo.roadmap.controller.dto.request.RoadmapRequestDto;
+import com.devdo.roadmap.controller.dto.response.RoadmapResponseDto;
+import com.devdo.roadmap.entity.Roadmap;
+import com.devdo.roadmap.repository.RoadmapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@RequiredArgsConstructor
+public class RoadmapService {
+
+    private final RoadmapRepository roadmapRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long createRoadmap(RoadmapRequestDto requestDto, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Roadmap roadmap = Roadmap.builder()
+                .title(requestDto.title())
+                .member(member)
+                .build();
+
+        roadmapRepository.save(roadmap);
+        return roadmap.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<RoadmapResponseDto> getMyRoadmaps(Long memberId) {
+        return roadmapRepository.findAllByMember_MemberId(memberId).stream()
+                .map(r -> RoadmapResponseDto.builder()
+                        .roadmapId(r.getId())
+                        .title(r.getTitle())
+                        .build()
+                ).collect(toList());
+    }
+
+    @Transactional
+    public void updateRoadmap(Long roadmapId, String newTitle) {
+        Roadmap roadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 로드맵이 존재하지 않습니다."));
+        roadmap.updateTitle(newTitle);
+    }
+
+    @Transactional
+    public void deleteRoadmap(Long roadmapId) {
+        roadmapRepository.deleteById(roadmapId);
+    }
+}


### PR DESCRIPTION
`로드맵`, `노드`, `노드 속 상세 페이지` 기능 구현했습니다.

<참고>
- `노드`와 `노드 속 상세 페이지`가 존재해도 `로드맵` 삭제 가능하게 구현했습니다.
- `노드 속 상세 페이지`가 존재해도 `노드` 삭제 가능하게 구현했습니다.
- `노드` 삭제 시 `노드 속 상세 페이지`가 함께 삭제되기 때문에 `노드 속 상세 페이지` 삭제는 구현하지 않았습니다.

AI 기능은 구현 끝내고 바로 추가해서 올리겠습니당