### PR TITLE
[Refactor/#59] - community 프로필 조회 자기자신 팔로우 여부 추가

### DIFF
--- a/DevDo/src/main/java/com/devdo/community/controller/dto/response/CommunityProfileResponseDto.java
+++ b/DevDo/src/main/java/com/devdo/community/controller/dto/response/CommunityProfileResponseDto.java
@@ -2,10 +2,12 @@ package com.devdo.community.controller.dto.response;
 
 import com.devdo.member.domain.Member;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record CommunityProfileResponseDto(
         Long memberId,
         String profilePicture,
@@ -18,10 +20,12 @@ public record CommunityProfileResponseDto(
         int followerCount,
         int followingCount,
         boolean isFollowing,
+        Boolean isMyProfile,
         List<CommunityAllResponseDto> myCommunities
 ) {
     public static CommunityProfileResponseDto from(Member member, String title, LocalDateTime createdAt,
                                                    Long viewCount, int commentCount, boolean isFollowing,
+                                                   Boolean isMyProfile,
                                                    List<CommunityAllResponseDto> myCommunities) {
         return new CommunityProfileResponseDto(
                 member.getMemberId(),
@@ -34,6 +38,7 @@ public record CommunityProfileResponseDto(
                 member.getFollowerCount(),
                 member.getFollowingCount(),
                 isFollowing,
+                isMyProfile,
                 myCommunities
         );
     }

--- a/DevDo/src/main/java/com/devdo/community/service/CommunityService.java
+++ b/DevDo/src/main/java/com/devdo/community/service/CommunityService.java
@@ -158,6 +158,9 @@ public class CommunityService {
         // 팔로우 여부 확인
         boolean isFollowing = followRepository.existsByFromMemberAndToMember(loginMember, toMember);
 
+        // 자신 프로필 여부 확인
+        boolean isMyProfile = loginMember.getMemberId().equals(toMember.getMemberId());
+
         return CommunityProfileResponseDto.from(
                 toMember,
                 community.getTitle(),
@@ -165,6 +168,7 @@ public class CommunityService {
                 community.getViewCount(),
                 commentCount,
                 isFollowing,
+                isMyProfile ? true : null,
                 myCommunities
         );
     }


### PR DESCRIPTION
Refactor/#59: community 프로필 조회 자기자신 팔로우 여부 추가

클라이언트의 요청으로 팔로우 리스트에 있던 isMyProfile 필드를 커뮤니티 페이지에서 다른 사람 프로필 조회 api에도 추가