### PR TITLE
[Feat/#65] - JSON 파싱 이슈 해결

### DIFF
--- a/DevDo/src/main/java/com/devdo/common/jackson/NewlineSanitizer.java
+++ b/DevDo/src/main/java/com/devdo/common/jackson/NewlineSanitizer.java
@@ -1,0 +1,17 @@
+package com.devdo.common.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+public class NewlineSanitizer extends JsonDeserializer<String> {
+    @Override
+    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String value = p.getValueAsString();
+        if (value == null) return null;
+        // 줄바꿈이 들어오면 JSON escape 형태로 변환
+        return value.replace("\r\n", "\n").replace("\r", "\n");
+    }
+}

--- a/DevDo/src/main/java/com/devdo/nodepage/controller/dto/request/NodePageRequestDto.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/controller/dto/request/NodePageRequestDto.java
@@ -1,6 +1,10 @@
 package com.devdo.nodepage.controller.dto.request;
 
+import com.devdo.common.jackson.NewlineSanitizer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 public record NodePageRequestDto(
+        @JsonDeserialize(using = NewlineSanitizer.class)
         String content,
         String emoji,
         String pictureUrl


### PR DESCRIPTION
아래 내용은 #65 내용과 일치합니당

---

클라이언트(프론트)에서 전송한 메시지를 처리할 때, 줄바꿈 시 **HttpMessageNotReadableException** 오류가 발생

**[해결방법]**
프론트에서 `<textarea>`를 활용하여 실제 줄바꿈을 `\n` 문자로 저장
(JS에서 이 데이터를 JSON으로 변환할 때 자동으로 escape됨)

`\n` 문자가 그대로 유지되므로 Jackson이 문제 없이 파싱 가능

서버는 받은 JSON을 DTO로 매핑, DTO의 String content 필드에는 줄바꿈이 그대로 포함됨

프론트에서 HTML `<pre>` 이나 CSS `white-space: pre-wrap` 을 적용하면 줄바꿈 그대로 보여짐

* 테스트로 Swagger 입력 시 아래 사진과 같이 줄바꿈은 `\n` 로 입력해야함 (ex `안녕\n하세용`)
<img width="1440" height="619" alt="Image" src="https://github.com/user-attachments/assets/ea19da89-bf78-4cc3-a935-8c08e8b1c7d5" />