### PR TITLE
[Feat/#69] - S3 스케줄러를 이용한 미사용 이미지 자동 삭제

### DIFF
--- a/DevDo/src/main/java/com/devdo/DevDoApplication.java
+++ b/DevDo/src/main/java/com/devdo/DevDoApplication.java
@@ -2,8 +2,10 @@ package com.devdo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DevDoApplication {
 
     public static void main(String[] args) {

--- a/DevDo/src/main/java/com/devdo/nodepage/entity/NodePage.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/entity/NodePage.java
@@ -3,6 +3,9 @@ package com.devdo.nodepage.entity;
 import com.devdo.node.entity.Node;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -31,6 +34,10 @@ public class NodePage {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "node_id", nullable = false)
     private Node node;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
 
     public void updateContent(String content) {
         this.content = content;

--- a/DevDo/src/main/java/com/devdo/nodepage/repository/NodePageRepository.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/repository/NodePageRepository.java
@@ -3,8 +3,13 @@ package com.devdo.nodepage.repository;
 import com.devdo.nodepage.entity.NodePage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface NodePageRepository extends JpaRepository<NodePage, Long> {
     Optional<NodePage> findByNode_NodeId(Long nodeId);
+
+    // Node와 연결되지 않고 사진이 있는 NodePage를 찾는 새로운 쿼리 메서드
+    List<NodePage> findByPictureUrlIsNotNullAndNodeIsNullAndCreatedAtBefore(LocalDateTime timestamp);
 }

--- a/DevDo/src/main/java/com/devdo/nodepage/service/NodePageService.java
+++ b/DevDo/src/main/java/com/devdo/nodepage/service/NodePageService.java
@@ -10,11 +10,14 @@ import com.devdo.nodepage.controller.dto.response.NodePageResponseDto;
 import com.devdo.nodepage.entity.NodePage;
 import com.devdo.nodepage.repository.NodePageRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -89,5 +92,19 @@ public class NodePageService {
                 nodePage.getEmoji(),
                 nodePage.getPictureUrl()
         );
+    }
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 3시 0분에 실행
+    @Transactional
+    public void deleteUnusedImages() {
+        // 24시간 전에 생성되었으며 노드와 연결되지 않은 NodePage를 찾음
+        LocalDateTime twentyFourHoursAgo = LocalDateTime.now().minusHours(24);
+        List<NodePage> orphanedPages = nodePageRepository
+                .findByPictureUrlIsNotNullAndNodeIsNullAndCreatedAtBefore(twentyFourHoursAgo);
+
+        for (NodePage page : orphanedPages) {
+            s3Service.deleteFile(page.getPictureUrl()); // S3에서 이미지 파일 삭제
+            nodePageRepository.delete(page); // DB에서 NodePage 레코드 삭제
+        }
     }
 }


### PR DESCRIPTION
- S3 스케줄러를 이용한 미사용 이미지 자동 삭제
- 스케줄러를 활용하여 매일 새벽 3시에 Node와 연결되지 않은 이미지 중,  업로드된 지 24시간이 지난 이미지를 S3 버킷과 데이터베이스에서 삭제하도록 자동화
- 불필요한 비용을 절감하고 시스템의 효율성을 높임

새벽 3시에 한 이유는용,,
대부분의 온라인 서비스는 새벽 시간대(일반적으로 자정부터 새벽 5시)에 사용량이 가장 적다고 합니당
낮 시간대에 실행하면 API 응답 속도가 느려지거나 서버가 불안정할 수도 있음 + 새벽에 하면 사용자가 작성한 내용을 해치지 않고 백그라운드 작업을 처리 + 다른 중요한 요청 처리와 충돌 없이 효율적으로 작업 가능 등의 이유 입니당....!