### PR TITLE
[Feat/#71] - Roadmap Template 기능 구현

### DIFF
--- a/DevDo/src/main/java/com/devdo/common/error/ErrorCode.java
+++ b/DevDo/src/main/java/com/devdo/common/error/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
     COMMUNITY_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 게시글이 없습니다. communityId = ", "NOT_FOUND_404"),
     NODE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 노드가 없습니다. nodeId = ", "NOT_FOUND_404"),
     ROADMAP_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 로드맵이 없습니다. roadmapId = ", "NOT_FOUND_404"),
-
+    ROADMAP_TEMPLATE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "템플릿을 찾을 수 없습니다. templateType =", "NOT_FOUND_404"),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다", "INTERNAL_SERVER_ERROR_500");

--- a/DevDo/src/main/java/com/devdo/node/entity/Node.java
+++ b/DevDo/src/main/java/com/devdo/node/entity/Node.java
@@ -45,6 +45,7 @@ public class Node {
 
     // 자식 노드
     @OneToMany(mappedBy = "parentNode", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<Node> children = new ArrayList<>();
 
     @OneToOne(mappedBy = "node", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/DevDo/src/main/java/com/devdo/roadmap/controller/RoadmapController.java
+++ b/DevDo/src/main/java/com/devdo/roadmap/controller/RoadmapController.java
@@ -5,6 +5,7 @@ import com.devdo.roadmap.controller.dto.response.RoadmapDetailResponseDto;
 import com.devdo.roadmap.controller.dto.response.RoadmapMainResponseDto;
 import com.devdo.roadmap.controller.dto.response.RoadmapResponseDto;
 import com.devdo.roadmap.service.RoadmapService;
+import com.devdo.roadmaptemplate.controller.dto.request.RoadmapTemplateRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/roadmap")
@@ -27,6 +29,19 @@ public class RoadmapController {
                               Principal principal) {
         Long memberId = Long.parseLong(principal.getName());
         return roadmapService.createRoadmap(roadmapRequestDto, memberId);
+    }
+
+    @PostMapping("/template")
+    @Operation(method = "POST", summary = "템플릿으로 로드맵 생성", description = "미리 정의된 [Frontend, Backend, 협업] 템플릿을 사용하여 로드맵을 생성합니다.")
+    public Long createRoadmapFromTemplate(
+            @RequestBody RoadmapTemplateRequestDto requestDto,
+            Principal principal) {
+        Long memberId = Long.parseLong(principal.getName());
+        return roadmapService.createRoadmapFromTemplate(
+                requestDto.title(),
+                requestDto.templateType(),
+                memberId
+        );
     }
 
     @GetMapping("/my")

--- a/DevDo/src/main/java/com/devdo/roadmap/service/RoadmapService.java
+++ b/DevDo/src/main/java/com/devdo/roadmap/service/RoadmapService.java
@@ -4,17 +4,25 @@ import com.devdo.common.error.ErrorCode;
 import com.devdo.common.exception.BusinessException;
 import com.devdo.member.domain.Member;
 import com.devdo.member.domain.repository.MemberRepository;
+import com.devdo.node.entity.Node;
+import com.devdo.node.repository.NodeRepository;
 import com.devdo.roadmap.controller.dto.request.RoadmapRequestDto;
 import com.devdo.roadmap.controller.dto.response.RoadmapDetailResponseDto;
 import com.devdo.roadmap.controller.dto.response.RoadmapMainResponseDto;
 import com.devdo.roadmap.controller.dto.response.RoadmapResponseDto;
 import com.devdo.roadmap.entity.Roadmap;
 import com.devdo.roadmap.repository.RoadmapRepository;
+import com.devdo.roadmaptemplate.entity.TemplateNode;
+import com.devdo.roadmaptemplate.entity.TemplateRoadmap;
+import com.devdo.roadmaptemplate.repository.TemplateNodeRepository;
+import com.devdo.roadmaptemplate.repository.TemplateRoadmapRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
 
@@ -24,6 +32,9 @@ public class RoadmapService {
 
     private final RoadmapRepository roadmapRepository;
     private final MemberRepository memberRepository;
+    private final TemplateRoadmapRepository templateRoadmapRepository;
+    private final TemplateNodeRepository templateNodeRepository;
+    private final NodeRepository nodeRepository;
 
     @Transactional
     public Long createRoadmap(RoadmapRequestDto requestDto, Long memberId) {
@@ -37,6 +48,58 @@ public class RoadmapService {
 
         roadmapRepository.save(roadmap);
         return roadmap.getId();
+    }
+
+    @Transactional
+    public Long createRoadmapFromTemplate(String roadmapTitle, String templateType, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION, ErrorCode.MEMBER_NOT_FOUND_EXCEPTION.getMessage()));
+
+        Roadmap newRoadmap = Roadmap.builder()
+                .title(roadmapTitle)
+                .member(member)
+                .build();
+        roadmapRepository.save(newRoadmap);
+
+        // type에 맞는 템플릿 로드맵의 노드 조회
+        TemplateRoadmap templateRoadmap = templateRoadmapRepository.findByType(templateType)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROADMAP_TEMPLATE_NOT_FOUND_EXCEPTION, ErrorCode.ROADMAP_TEMPLATE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        List<TemplateNode> templateNodes = templateNodeRepository.findAllByTemplateRoadmapId(templateRoadmap.getId());
+
+        Map<Long, Node> copiedNodesMap = new HashMap<>();
+
+        // 템플릿 노드들을 복사하여 새로운 로드맵의 노드로 저장
+        for (TemplateNode templateNode : templateNodes) {
+            Node newNode = Node.builder()
+                    .nodeName(templateNode.getNodeName())
+                    .nodeShape(templateNode.getNodeShape())
+                    .nodeColor(templateNode.getNodeColor())
+                    .link(templateNode.getLink())
+                    .roadmap(newRoadmap)
+                    // .parentNode는 두 번째 루프에서 설정함
+                    .build();
+
+            // 새로운 노드를 저장하고 맵에 추가 (나중에 부모-자식 관계 설정용)
+            Node savedNode = nodeRepository.save(newNode);
+            copiedNodesMap.put(templateNode.getId(), savedNode);
+        }
+
+        // 모든 노드가 생성된 후 부모자식 관계 설정
+        for (TemplateNode templateNode : templateNodes) {
+            if (templateNode.getParentNodeId() != null) {
+                Node newChildNode = copiedNodesMap.get(templateNode.getId());
+                Node newParentNode = copiedNodesMap.get(templateNode.getParentNodeId());
+
+                // 부모 노드 설정
+                if (newParentNode != null) {
+                    newParentNode.addChild(newChildNode);
+                    nodeRepository.save(newParentNode);
+                }
+            }
+        }
+
+        return newRoadmap.getId();
     }
 
     @Transactional(readOnly = true)

--- a/DevDo/src/main/java/com/devdo/roadmaptemplate/controller/dto/request/RoadmapTemplateRequestDto.java
+++ b/DevDo/src/main/java/com/devdo/roadmaptemplate/controller/dto/request/RoadmapTemplateRequestDto.java
@@ -1,0 +1,7 @@
+package com.devdo.roadmaptemplate.controller.dto.request;
+
+public record RoadmapTemplateRequestDto(
+        String title,
+        String templateType
+) {
+}

--- a/DevDo/src/main/java/com/devdo/roadmaptemplate/entity/TemplateNode.java
+++ b/DevDo/src/main/java/com/devdo/roadmaptemplate/entity/TemplateNode.java
@@ -1,0 +1,32 @@
+package com.devdo.roadmaptemplate.entity;
+
+import com.devdo.node.entity.NodeColor;
+import com.devdo.node.entity.NodeShape;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TemplateNode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String nodeName;
+
+    @Enumerated(EnumType.STRING)
+    private NodeShape nodeShape;
+
+    @Enumerated(EnumType.STRING)
+    private NodeColor nodeColor;
+
+    private String link;
+    private Long parentNodeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "template_roadmap_id")
+    private TemplateRoadmap templateRoadmap;
+}

--- a/DevDo/src/main/java/com/devdo/roadmaptemplate/entity/TemplateRoadmap.java
+++ b/DevDo/src/main/java/com/devdo/roadmaptemplate/entity/TemplateRoadmap.java
@@ -1,0 +1,19 @@
+package com.devdo.roadmaptemplate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TemplateRoadmap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 템플릿의 종류 (Frontend, Backend, 협업)
+    private String type;
+}

--- a/DevDo/src/main/java/com/devdo/roadmaptemplate/repository/TemplateNodeRepository.java
+++ b/DevDo/src/main/java/com/devdo/roadmaptemplate/repository/TemplateNodeRepository.java
@@ -1,0 +1,16 @@
+package com.devdo.roadmaptemplate.repository;
+
+
+import com.devdo.roadmaptemplate.entity.TemplateNode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TemplateNodeRepository extends JpaRepository<TemplateNode, Long> {
+
+    // 특정 템플릿 로드맵에 속한 모든 노드를 찾음
+    List<TemplateNode> findAllByTemplateRoadmapId(Long templateRoadmapId);
+
+    // 계층 구조 복사 (부모 노드 ID로 자식 노드를 찾음)
+    List<TemplateNode> findAllByParentNodeId(Long parentNodeId);
+}

--- a/DevDo/src/main/java/com/devdo/roadmaptemplate/repository/TemplateRoadmapRepository.java
+++ b/DevDo/src/main/java/com/devdo/roadmaptemplate/repository/TemplateRoadmapRepository.java
@@ -1,0 +1,12 @@
+package com.devdo.roadmaptemplate.repository;
+
+import com.devdo.roadmaptemplate.entity.TemplateRoadmap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TemplateRoadmapRepository extends JpaRepository<TemplateRoadmap, Long> {
+
+    // type으로 TemplateRoadmap 엔티티를 찾음
+    Optional<TemplateRoadmap> findByType(String type);
+}


### PR DESCRIPTION
기존의 Roadmap 및 Node 테이블과 분리된 `TemplateRoadmap`과 `TemplateNode` 테이블을 새로 만들었습니다. 
사용자가 템플릿을 수정해도 원본 데이터가 변경되지 않도록 구현했습니당

사용자가 템플릿으로 로드맵을 생성하면 `RoadmapService`의 `createRoadmapFromTemplate` 메서드가 템플릿 노드들을 읽어 새로운 Node 엔티티로 복사합니다. 이 과정에서 `nodeName`, `nodeShape`, `nodeColor` 등 모든 속성이 완벽하게 복제 되는 형식으로 구현했습니당

템플릿 관련 데이터도 채워넣었습니다!

<img width="1203" height="567" alt="image" src="https://github.com/user-attachments/assets/8c966a8d-8780-4a01-a990-5aeeb21a8db0" />

```
{
  "title": "나만의 백엔드 로드맵", // 원하는 제목 입력
  "templateType": "Backend" // Frontend, Backend, 협업 중 선택하여 작성
}
```
위와 같이 작성하면 됩니당